### PR TITLE
feat: update to 20.04 as base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM ubuntu:bionic
+FROM ubuntu:20.04
+ENV container=docker DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8
+LABEL org.opensafely.base=true
 
-RUN apt-get update
-RUN apt-get install -y sysstat lsof net-tools tcpdump vim
+# install some base tools we want in all images
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y sysstat lsof net-tools tcpdump vim strace && \
+    apt-get autoremove -y


### PR DESCRIPTION
This make python3.8 the default, and is more current in general.

We also hardcode some env vars for convenience when building FROM this
image.

Note: this won't break anything by landing, but might do when we next build the various other images. However, once this lands, I will be working on moving them all over and ensuring it all works.