### PR TITLE
Add base entrypoint

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -11,7 +11,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Build image
-      run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      run: make build
+    - name: Run tests
+      run: make test
     - name: Log into GitHub Container Registry
       run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
     - name: Push image to GitHub Container Registry

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,15 @@
+name: Run tests
+on:
+  pull_request:
+env:
+  IMAGE_NAME: base-docker
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Build image
+      run: make build
+    - name: Run tests
+      run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,7 @@ COPY docker-apt-install.sh /root/docker-apt-install.sh
 
 # install some base tools we want in all images
 RUN UPGRADE=yes /root/docker-apt-install.sh sysstat lsof net-tools tcpdump vim strace
+
+
+COPY entrypoint.sh /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+IMAGE_NAME ?= base-docker-test
+INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
+
+.PHONY: build
+build:
+	docker build . --tag $(IMAGE_NAME) 
+
+.PHONY: test
+ifdef INTERACTIVE
+test: RUN_ARGS=-it
+else
+test: RUN_ARGS=
+endif
+test:
+	docker run $(RUN_ARGS) --rm -v $(PWD):/tests -w /tests $(IMAGE_NAME) ./tests.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+executable=${ACTION_EXEC:-bash}
+
+if test -n "${1:-}"; then
+    if command -v -- "$1" >/dev/null 2>&1; then
+        # special case - the user has provided their own valid executable as
+        # the first argument, so switch to executing that
+        executable=$1
+        shift
+    fi
+fi
+
+exec "$executable" "$@"

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Note: idealy, we'd use python, but the base-docker image does not have it
+# installed!
+set -euo pipefail
+
+failed=0
+
+success() {
+    echo "OK: $*"
+}
+
+failure() {
+    echo "FAIL: $*"
+    failed=1
+}
+
+# test string is an executable on the path
+test_executable() {
+    local exe=$1
+    if command -v "$exe" > /dev/null; then
+        success "$exe"
+    else
+        failure "$exe - could not find $exe"
+    fi
+}
+
+
+# test script that just echos its arguments.
+script=$(mktemp)
+chmod +x "$script"
+# Quoting EOF disables expansion. Obvs.
+cat > "$script" << 'EOF'
+#!/bin/bash
+echo "$0" "$@"
+EOF
+
+
+# test that the entrypoint is invoked properly
+test_entrypoint() {
+    local exe output expected
+    output=$(/root/entrypoint.sh "$@")
+    if test -n "${ACTION_EXEC:-}"; then
+        expected="${script} $*"
+    else
+        expected="$*"
+    fi
+    if test "${output}" = "$expected"; then
+        success "entrypoint.sh $*"
+    else
+        failure "'entrypoint.sh $*' did not return correct output"
+        echo "output='$output'"
+        echo "expected='$expected'"
+    fi
+}
+
+test_executable iostat
+test_executable lsof
+test_executable netstat
+test_executable tcpdump
+test_executable vim
+test_executable strace
+
+
+export ACTION_EXEC=$script
+test_entrypoint " "
+test_entrypoint a -b --ccc
+unset ACTION_EXEC
+test_entrypoint "$script" a -b --ccc
+
+exit $failed
+


### PR DESCRIPTION
 - defaults to bash
 - if first argument is an executable, runs that instead
 - basic test coverage too

Note: the tests are implemented in bash as we have no python environment
nor python in the base image.