### PR TITLE
Use Buildkit to build and add build metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.2
 FROM ubuntu:20.04
 
 # default env vars
@@ -7,8 +8,7 @@ ENV container=docker DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8
 LABEL maintainer="tech@opensafely.org" \
       org.label-schema.schema-version="1.0" \
       org.label-schema.url="opensafely.org" \
-      org.label-schema.vendor="OpenSAFELY" \
-      org.opensafely.base=true
+      org.label-schema.vendor="OpenSAFELY"
 
 # useful utility for installing apt packages in the most space efficient way
 # possible.  It's worth it because this is the base image, and so any bloat
@@ -22,3 +22,10 @@ RUN UPGRADE=yes /root/docker-apt-install.sh sysstat lsof net-tools tcpdump vim s
 
 COPY entrypoint.sh /root/entrypoint.sh
 ENTRYPOINT ["/root/entrypoint.sh"]
+
+# record build info so downstream images know about the base image they were
+# built from
+ARG BASE_BUILD_DATE
+ARG BASE_GITREF
+LABEL org.opensafely.base.build-date=$BASE_BUILD_DATE \
+      org.opensafely.base.vcs-ref=$BASE_GITREF

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 IMAGE_NAME ?= base-docker-test
 INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
+export DOCKER_BUILDKIT=1
 
 .PHONY: build
+build: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
+build: GITREF=$(shell git rev-parse --short HEAD)
 build:
-	docker build . --tag $(IMAGE_NAME) 
+	docker build . --tag $(IMAGE_NAME) \
+		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/base-docker \
+		--build-arg BASE_BUILD_DATE=$(BUILD_DATE) --build-arg BASE_GITREF=$(GITREF)
 
 .PHONY: test
 ifdef INTERACTIVE


### PR DESCRIPTION
 - buildkit is faster and can use registry as a remote layer cache
 - base layer build metadata will be useful for downstream images