### PR TITLE
Split into `base-docker` and `base-action` images

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -2,8 +2,12 @@ name: Build docker image and publish
 on:
   push:
     branches: [master]
+  schedule:
+    # build and publish a new base image every week at 04:17am on mondays
+    - cron: "17 04 * * 1"
 env:
-  IMAGE_NAME: base-docker
+  BASE_IMAGE_NAME: base-docker
+  ACTION_IMAGE_NAME: base-action
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,15 +15,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Build image
-      run: make build
+      run: make clean-build
     - name: Run tests
       run: make test
     - name: Run lint
       run: make lint
     - name: Log into GitHub Container Registry
-      run: docker login https://ghcr.io -u ${{ github.actor }} --password ${{ secrets.DOCKER_RW_TOKEN }}
+      run: echo ${{ secrets.DOCKER_RW_TOKEN }} | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
     - name: Push image to GitHub Container Registry
       run: |
-        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-        docker tag $IMAGE_NAME $IMAGE_ID:latest
-        docker push $IMAGE_ID:latest
+        BASE_IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$BASE_IMAGE_NAME
+        ACTION_IMAGE_ID=ghcr.io/${{ github.repository_owner }}/ACTION_IMAGE_NAME
+        docker tag $BASE_IMAGE_NAME $BASE_IMAGE_ID:latest
+        docker tag $ACTION_IMAGE_NAME $ACTION_IMAGE_ID:latest
+        docker push $BASE_IMAGE_ID:latest
+        docker push $ACTION_IMAGE_ID:latest

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Push image to GitHub Container Registry
       run: |
         BASE_IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$BASE_IMAGE_NAME
-        ACTION_IMAGE_ID=ghcr.io/${{ github.repository_owner }}/ACTION_IMAGE_NAME
+        ACTION_IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$ACTION_IMAGE_NAME
         docker tag $BASE_IMAGE_NAME $BASE_IMAGE_ID:latest
         docker tag $ACTION_IMAGE_NAME $ACTION_IMAGE_ID:latest
         docker push $BASE_IMAGE_ID:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM ubuntu:20.04
+FROM ubuntu:20.04 as base-docker
 
 # default env vars
 ENV container=docker DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8
@@ -20,13 +20,15 @@ COPY docker-apt-install.sh /root/docker-apt-install.sh
 # install some base tools we want in all images
 RUN UPGRADE=yes /root/docker-apt-install.sh sysstat lsof net-tools tcpdump vim strace
 
-
-COPY entrypoint.sh /root/entrypoint.sh
-ENTRYPOINT ["/root/entrypoint.sh"]
-
 # record build info so downstream images know about the base image they were
 # built from
 ARG BASE_BUILD_DATE
 ARG BASE_GITREF
 LABEL org.opensafely.base.build-date=$BASE_BUILD_DATE \
       org.opensafely.base.vcs-ref=$BASE_GITREF
+
+FROM base-docker as base-action
+
+# special action entrypoing
+COPY entrypoint.sh /root/entrypoint.sh
+ENTRYPOINT ["/root/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,28 @@
-IMAGE_NAME ?= base-docker-test
+BASE_IMAGE_NAME ?= base-docker
+ACTION_IMAGE_NAME ?= base-action
 INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
 export DOCKER_BUILDKIT=1
 
-.PHONY: build
-build: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
-build: GITREF=$(shell git rev-parse --short HEAD)
-build:
-	docker build . --tag $(IMAGE_NAME) \
+.PHONY: build-base
+build-base: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
+build-base: GITREF=$(shell git rev-parse --short HEAD)
+build-base:
+	docker build . --tag $(BASE_IMAGE_NAME) --target base-docker \
 		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/base-docker \
-		--build-arg BASE_BUILD_DATE=$(BUILD_DATE) --build-arg BASE_GITREF=$(GITREF)
+		--build-arg BASE_BUILD_DATE=$(BUILD_DATE) --build-arg BASE_GITREF=$(GITREF) $(ARGS)
+
+.PHONY: build-action
+build-action:
+	docker build . --tag $(ACTION_IMAGE_NAME) --target base-action \
+		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/base-action $(ARGS)
+
+.PHONY: build
+build: build-base build-action
+
+.PHONY: clean-build
+clean-build: ARGS=--no-cache
+clean-build: build-base build-action
+
 
 .PHONY: test
 ifdef INTERACTIVE
@@ -17,7 +31,7 @@ else
 test: RUN_ARGS=
 endif
 test:
-	docker run $(RUN_ARGS) --rm -v $(PWD):/tests -w /tests $(IMAGE_NAME) ./tests.sh
+	docker run $(RUN_ARGS) --rm -v $(PWD):/tests -w /tests $(ACTION_IMAGE_NAME) ./tests.sh
 
 
 .PHONY: lint

--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
-# base-docker
+# Docker Base Images
 
-A docker base image for action docker images within the OpenSAFELY framework.
+Base docker images for the OpenSAFELY framework. These provide a common, up to
+date base image to build on top of.
 
-Provides an up-to-date Ubuntu 20.04 base along with common debugging tools.
-(e.g. `strace`)
+This repo produces two image: `base-docker`, and `base-action`.
 
-Additionally it includes a helpful script for installing apt packages in the
-most docker-space-efficient manner. Adding this and using it in this and
-dependent images saves over 100MB, typically.
+## base-docker
+
+This image is up-to-date Ubuntu 20.04 base along with common debugging tools.
+(e.g. `strace`).
+
+It includes a helpful script for installing apt packages in the most docker
+friendly space-efficient manner. Adding this and using it in this and dependent
+images saves over 100MB, typically.
+
+It is rebuilt and publish weekly, so there's always a fresh base to build from.
+
+
+## base-action
+
+This is built from `base-docker` but also include a base action entrypoint,
+which supports the actions are used in OpenSAFELY's 
+[project.yaml](https://docs.opensafely.org/actions-pipelines/)
+This entrypoint supports invoking actions with both an explicit custom CMD or an
+implicit one. i.e. 
+
+     run: python:latest python myscript.py option1 option2
+
+or
+     run: python:latest myscript.py option1 option2
+
+Images built from base-action can define `ACTION_EXEC` env var to customise the
+default implicit executable used to execute.
+

--- a/docker-apt-install.sh
+++ b/docker-apt-install.sh
@@ -9,16 +9,19 @@ apt-get update
 # do we want to upgrade too?
 test "${UPGRADE:-}" = "yes" && apt-get upgrade --yes
 
+PACKAGES=
 for arg in "$@"; do
     if test -f $arg; then
         # argument is a file
         # strip any comments and install every package listed in the file
         sed 's/^#.*//' "$arg" | xargs apt-get install --yes --no-install-recommends
     else
-        # argument is a package name, just install it
-        apt-get install --yes --no-install-recommends "$arg"
+        # argument is a package name, add to install list
+        PACKAGES="$PACKAGES $arg"
     fi
 done
+
+test -n "$PACKAGES" && apt-get install --yes --no-install-recommends $PACKAGES
 
 # clean up if we've upgraded
 test "${UPGRADE:-}" = "yes" && apt-get autoremove --yes


### PR DESCRIPTION
This is because we want to use a standard base-docker image in
a non-action context, so split out the action entrypoint stuff into
a separate image.

Additionally, scheduled a clean build every week. This ensure that we'll
have an up to date base image.

However, it does mean that our users will need to pull down entire
images when they are rebuilt, as the base layer will have changed. So
it's important they are as small as possible.

Also made a small tweak to the apt installer script, to be more
efficient when passed a list of packages as cli args.