### PR TITLE
publish both 20.04 and 22.04 images

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -28,7 +28,19 @@ jobs:
       run: |
         BASE_IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$BASE_IMAGE_NAME
         ACTION_IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$ACTION_IMAGE_NAME
-        docker tag $BASE_IMAGE_NAME $BASE_IMAGE_ID:latest
-        docker tag $ACTION_IMAGE_NAME $ACTION_IMAGE_ID:latest
+        # tag the local images with the published names
+        docker tag $BASE_IMAGE_NAME:20.04 $BASE_IMAGE_ID:20.04
+        docker tag $BASE_IMAGE_NAME:22.04 $BASE_IMAGE_ID:22.04
+        # action images are 20.04 based currently
+        docker tag $ACTION_IMAGE_NAME:20.04 $ACTION_IMAGE_ID:20.04
+
+        # push each label up
+        docker push $BASE_IMAGE_ID:20.04
+        docker push $BASE_IMAGE_ID:22.04
+        docker push $ACTION_IMAGE_ID:20.04
+        
+        # latest tags are 20.04 for b/w compat
+        docker tag $BASE_IMAGE_NAME:20.04 $BASE_IMAGE_ID:latest
+        docker tag $ACTION_IMAGE_NAME:20.04 $ACTION_IMAGE_ID:latest
         docker push $BASE_IMAGE_ID:latest
         docker push $ACTION_IMAGE_ID:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile:1.2
-FROM ubuntu:20.04 as base-docker
+ARG UBUNTU_IMAGE=ubuntu:20.04
+# we are parameterizing the base image, so we can't be explicit like DL3006 wants us to be
+# hadolint ignore=DL3006
+FROM $UBUNTU_IMAGE as base-docker
 
 # default env vars
 ENV container=docker DEBIAN_FRONTEND=noninteractive LANG=C.UTF-8 LC_ALL=C.UTF-8

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,26 @@ INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
 export DOCKER_BUILDKIT=1
 
 .PHONY: build-base
-build-base: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
-build-base: GITREF=$(shell git rev-parse --short HEAD)
 build-base:
-	docker build . --tag $(BASE_IMAGE_NAME) --target base-docker \
+	$(MAKE) build-version UBUNTU_VERSION=20.04 ARGS=$(ARGS)
+	docker tag $(BASE_IMAGE_NAME):20.04 $(BASE_IMAGE_NAME):latest
+	$(MAKE) build-version UBUNTU_VERSION=22.04 ARGS=$(ARGS)
+
+
+build-version: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
+build-version: GITREF=$(shell git rev-parse --short HEAD)
+build-version: UBUNTU_VERSION ?= 20.04
+build-version:
+	docker build . --pull --target base-docker \
+		--build-arg UBUNTU_IMAGE=ubuntu:$(UBUNTU_VERSION) --tag $(BASE_IMAGE_NAME):$(UBUNTU_VERSION) \
 		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/base-docker \
 		--build-arg BASE_BUILD_DATE=$(BUILD_DATE) --build-arg BASE_GITREF=$(GITREF) $(ARGS)
 
+
 .PHONY: build-action
 build-action:
-	docker build . --tag $(ACTION_IMAGE_NAME) --target base-action \
+	docker build . --tag $(ACTION_IMAGE_NAME) --tag $(ACTION_IMAGE_NAME):20.04 --target base-action \
+		--build-arg UBUNTU_IMAGE=ubuntu:20.04 \
 		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/base-action $(ARGS)
 
 .PHONY: build


### PR DESCRIPTION
Acheived by parameterising the base FROM image in the docker file.

Note: the default :latest tag is still 20.04, so downstream images need
explicitly opt in to use 22.04.
