### PR TITLE
fix the build arg based labels

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Build image
-      run: make clean-build
+      run: make build
     - name: Run tests
       run: make test
     - name: Run lint

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,18 @@
 BASE_IMAGE_NAME ?= base-docker
 ACTION_IMAGE_NAME ?= base-action
 INTERACTIVE:=$(shell [ -t 0 ] && echo 1)
+
+
 export DOCKER_BUILDKIT=1
-
-.PHONY: build-base
-build-base:
-	$(MAKE) build-version UBUNTU_VERSION=20.04 ARGS=$(ARGS)
-	docker tag $(BASE_IMAGE_NAME):20.04 $(BASE_IMAGE_NAME):latest
-	$(MAKE) build-version UBUNTU_VERSION=22.04 ARGS=$(ARGS)
+export BASE_BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
+export BASE_GITREF=$(shell git rev-parse --short HEAD)
 
 
-build-version: BUILD_DATE=$(shell date +'%y-%m-%dT%H:%M:%S.%3NZ')
-build-version: GITREF=$(shell git rev-parse --short HEAD)
-build-version: UBUNTU_VERSION ?= 20.04
-build-version:
-	docker build . --pull --target base-docker \
-		--build-arg UBUNTU_IMAGE=ubuntu:$(UBUNTU_VERSION) --tag $(BASE_IMAGE_NAME):$(UBUNTU_VERSION) \
-		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/base-docker \
-		--build-arg BASE_BUILD_DATE=$(BUILD_DATE) --build-arg BASE_GITREF=$(GITREF) $(ARGS)
+build:
+	docker-compose build --pull $(ARGS) base-docker-20.04 base-docker-22.04 base-action
 
-
-.PHONY: build-action
-build-action:
-	docker build . --tag $(ACTION_IMAGE_NAME) --tag $(ACTION_IMAGE_NAME):20.04 --target base-action \
-		--build-arg UBUNTU_IMAGE=ubuntu:20.04 \
-		--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/opensafely-core/base-action $(ARGS)
-
-.PHONY: build
-build: build-base build-action
-
-.PHONY: clean-build
 clean-build: ARGS=--no-cache
-clean-build: build-base build-action
+clean-build: build
 
 
 .PHONY: test
@@ -40,8 +21,9 @@ test: RUN_ARGS=-it
 else
 test: RUN_ARGS=
 endif
-test:
-	docker run $(RUN_ARGS) --rm -v $(PWD):/tests -w /tests $(ACTION_IMAGE_NAME) ./tests.sh
+test: build
+	docker run $(RUN_ARGS) --rm -v $(PWD):/tests -w /tests $(ACTION_IMAGE_NAME):20.04 ./tests.sh
+	./check-labels.sh
 
 
 .PHONY: lint

--- a/check-labels.sh
+++ b/check-labels.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+failed=0
+for image in base-docker:20.04 base-docker:22.04 base-action:20.04
+do
+    for label in build-date vcs-ref
+    do
+        full="org.opensafely.base.$label"
+        value="$(docker inspect -f "{{ index .Config.Labels \"$full\" }}" "$image")"
+
+        echo "$image: $full=$value"
+        test -n "$value" || { failed=1; echo "Empty $full label"; }
+    done
+done
+
+exit $failed

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,37 @@
+services:
+  base-docker:
+    build:
+      context: .
+      target: base-docker
+      cache_from:  # should speed up the build in CI, where we have a cold cache
+        - ghcr.io/opensafely-core/base-docker
+      args:
+        # this makes the image work for later cache_from: usage
+        - BUILDKIT_INLINE_CACHE=1
+        # env vars supplied by make/just
+        - BASE_BUILD_DATE
+        - BASE_GITREF
+    init: true
+
+  base-docker-20.04:
+    extends: base-docker
+    image: "base-docker:20.04"
+    build:
+      args:
+        - UBUNTU_VERSION=ubuntu:20.04
+
+  base-docker-22.04:
+    extends: base-docker
+    image: "base-docker:22.04"
+    build:
+      args:
+        - UBUNTU_VERSION=ubuntu:22.04
+
+  base-action:
+    extends: base-docker
+    image: "base-action:20.04"
+    build:
+      args:
+        - UBUNTU_VERSION=ubuntu:20.04
+      target: base-action
+


### PR DESCRIPTION
Due to quirk of multi-stagge docker builds, you need to set the build
args when you build all targets of the Dockerfile.

We do this by setting the args for the whole Makefile, and building the
whole lot in one invocation. That should mean that all images have the
same sha/build time labels
