### PR TITLE
Support a child image setting separate default interactive executable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-executable=${ACTION_EXEC:-bash}
+script_executable=${ACTION_EXEC:-bash}
+interactive_executable=${INTERACTIVE_EXEC:-$script_executable}
 
 is_real_executable() {
     local path shebang 
@@ -23,6 +24,11 @@ is_real_executable() {
 }
 
 if test -n "${1:-}"; then
+    # we have arguments, so default to executing a file
+    executable=$script_executable
+
+    # However, check if the first argument is a valid executable, and use that instead.
+    # This allows a pattern of `docker run image exec` to run whatever excuteable you want.
     if command -v -- "$1" >/dev/null 2>&1; then
         # on windows, all files have executable mask, so check it is actually executable
         if is_real_executable "$1"; then
@@ -32,6 +38,10 @@ if test -n "${1:-}"; then
             shift
         fi
     fi
+
+else
+    # no arguments - we want the interactive executable
+    executable=$interactive_executable
 fi
 
 exec "$executable" "$@"


### PR DESCRIPTION
When used in a project.yaml, there is always an executable or script
passed to an action image. However, when the image is used with
`opensafely exec`, there is not always any arguments passed, as the user
may just want a default interactive session.

Only our python image has an ACTION_EXEC executable that can both run
scripts and run interactively. So, for stata-mp and r images, both
have ACTION_EXECs that expect files and exit if one is not passed. Users
therefore have to have to do `opensafely exec stata-mp stata` and
`opensafely exec r R` respectively to run an interactive session from
the cli, which is awkward.

This adds suppot to entrypoint.sh to allow the child images to
optionally specify an INTERACTIVE_EXEC env var to be used when there are
no arguments at all.

We could do this in opensafely-cli, i.e. pass an argument if the user
does not pass any.

But that means opensafely-cli needs to know about what image has what
interactive executable. It's cleaned to have the image metadata define
that.

Note that in future, we expect to just use /usr/bin/R instead of
/usr/bin/Rscript for the r iamge's ACTION_EXEC, which like python can do
both script and interactive execution.

In that case, it's only stata that has the special case wrapper, so
maybe we could just fix it in the stata image in that case.
