### PR TITLE
Fix docker-api-install.sh

### DIFF
--- a/docker-apt-install.sh
+++ b/docker-apt-install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Useful utility to install system packages from a file
-# It does so in the lowest footprint way possible, by removing apt lists afterwards
+# It does so in the lowest footprint way possible, in a single RUN command.
 set -euo pipefail
 
 # ensure apt lists are populated
@@ -21,8 +21,12 @@ for arg in "$@"; do
     fi
 done
 
-# shellcheck disable=SC2086
-test -n "$PACKAGES" && apt-get install --yes --no-install-recommends $PACKAGES
+if test -n "$PACKAGES"; then
+    # shellcheck disable=SC2086
+    apt-get install --yes --no-install-recommends $PACKAGES
+fi
 
 # clean up if we've upgraded
-test "${UPGRADE:-}" = "yes" && apt-get autoremove --yes
+if test "${UPGRADE:-}" = "yes"; then
+    apt-get autoremove --yes 
+fi

--- a/tests.sh
+++ b/tests.sh
@@ -58,6 +58,9 @@ test_executable vim
 test_executable strace
 
 
+# test install works w/o UPDATE=yes
+/root/docker-apt-install.sh make
+
 # test script that just echos its arguments for testing
 script=$(mktemp /tmp/action_exec.XXXX.sh)
 chmod +x "$script"


### PR DESCRIPTION
Due to how the `test .. && ..` was constructed, it failed with exit code 1 when UPGRADE was not set.
Added test coverage for that case, and fixed to use `if; else` rather than
`test && ...` to avoid the failing exit code.

I am unsure why this suddenly started failing, but possibly to do with
the removal of the [/var/apt/lists commit](https://github.com/opensafely-core/base-docker/commit/6e9d8ec5c0597d26157dda15ba76d9911ed4913f) in the last PR.
